### PR TITLE
fix: Move player data load to OnClientPutInServer

### DIFF
--- a/Cookies/src/Cookies.cs
+++ b/Cookies/src/Cookies.cs
@@ -61,8 +61,8 @@ public partial class Cookies : BasePlugin
         }
     }
 
-    [EventListener<EventDelegates.OnClientSteamAuthorize>]
-    public void OnClientSteamAuthorize(IOnClientSteamAuthorizeEvent @event)
+    [EventListener<EventDelegates.OnClientPutInServer>]
+    public void IOnClientPutInServerEvent(IOnClientPutInServerEvent @event)
     {
         var playerid = @event.PlayerId;
 

--- a/Cookies/src/Cookies.cs
+++ b/Cookies/src/Cookies.cs
@@ -10,7 +10,7 @@ using SwiftlyS2.Shared.Plugins;
 
 namespace Cookies;
 
-[PluginMetadata(Id = "Cookies", Version = "1.0.9", Name = "Cookies", Author = "Swiftly Development Team")]
+[PluginMetadata(Id = "Cookies", Version = "1.0.10", Name = "Cookies", Author = "Swiftly Development Team")]
 public partial class Cookies : BasePlugin
 {
     private ConcurrentDictionary<long, Dictionary<string, object>> CachedCookies = new();


### PR DESCRIPTION
Sometimes player is not authorized when they join the server and cookies get reset for them.